### PR TITLE
feat(libcorn): libcorn Lua library export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,55 +10,129 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Update Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        name: Cache dependencies
+
+      - name: Install Lua
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends liblua5.4-dev
+
+      - name: Rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check
+
+      - name: Cargo Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          # only enable one lua feature since they're mutually exclusive
+          args: --all-targets --features wasm,lua54,bench -- -D warnings
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    
-    - name: Update Toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: clippy
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Install wasm-pack
-      uses: jetli/wasm-pack-action@v0.3.0
-      with:
-        version: 'latest'
-    
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --all-features
+      - name: Update Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
 
-    - name: Rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --check
+      - uses: Swatinem/rust-cache@v2
+        name: Cache dependencies
 
-    - name: Cargo Clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --all-targets --all-features -- -D warnings
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
 
-    - name: Cargo Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --profile release
-      env:
-        CORN_TEST: bar
+      - name: Cargo Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --profile release
+        env:
+          CORN_TEST: bar
 
-    - name: Wasm-Pack Test
-      # wasm-pack doesn't seem to work on the windows images
-      if: ${{ matrix.os != 'windows-latest' }}
-      run: wasm-pack test --node
-      working-directory: libcorn
+  build-wasm:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Update Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@v2
+        name: Cache dependencies
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.3.0
+        with:
+          version: 'latest'
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features wasm
+
+      - name: Wasm-Pack Test
+        run: wasm-pack test --node
+        working-directory: libcorn
+
+  build-lua:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lua: [ lua51, lua52, lua53, lua54, luajit, luajit52 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Update Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@v2
+        name: Cache dependencies
+
+      - name: Install Lua
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends liblua5.4-dev liblua5.3-dev liblua5.2-dev liblua5.1-0-dev libluajit-5.1-dev
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features ${{ matrix.lua }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +47,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -284,6 +302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "erased-serde"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6984864d65d092d9e9ada107007a846a09f75d2e24046bcce9a38d14aa52052"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +459,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "console_error_panic_hook",
  "criterion",
+ "mlua",
  "paste",
  "pest",
  "pest_derive",
@@ -463,6 +491,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lua-src"
+version = "546.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb00c1380f1b4b4928dd211c07301ffa34872a239e590bd3219d9e5b213face"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.4.7+resty107baaf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca76a3752fc130e5dabef71792f4f7095babb72f7c85860c7830eb746ad8bf31"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +529,40 @@ name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+
+[[package]]
+name = "mlua"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07366ed2cd22a3b000aed076e2b68896fb46f06f1f5786c5962da73c0af01577"
+dependencies = [
+ "bstr",
+ "cc",
+ "erased-serde",
+ "lua-src",
+ "luajit-src",
+ "mlua_derive",
+ "num-traits",
+ "once_cell",
+ "pkg-config",
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
+name = "mlua_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9214e60d3cf1643013b107330fcd374ccec1e4ba1eef76e7e5da5e8202e71c0"
+dependencies = [
+ "itertools",
+ "once_cell",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.102",
+]
 
 [[package]]
 name = "num-traits"
@@ -569,6 +650,12 @@ dependencies = [
  "pest",
  "sha2",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plotters"
@@ -668,6 +755,8 @@ version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -676,6 +765,12 @@ name = "regex-syntax"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1053,6 +1148,17 @@ dependencies = [
  "libc",
  "memory_units",
  "winapi",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -86,8 +86,35 @@ which can parse Corn into valid JavaScript objects.
 import * as corn from 'libcorn';
 
 const parsed = corn.parse('{foo = "bar"}');
-console.log(parsed) // { foo: "bar" }
+console.log(parsed) // Map(foo -> "bar")
 ```
+
+### Lua
+
+Lua support can be built into the library using __one of__ the feature flags,
+allowing you to bind directly to `libcorn.so`:
+
+- `lua51`
+- `lua52`
+- `lua53`
+- `lua54`
+- `luajit`
+- `luajit52`
+
+So long as `libcorn.so` is in Lua's module path, it can be then be used as below:
+
+```lua
+local libcorn = require("libcorn")
+local success, res = pcall(libcorn.parse, '{foo = "bar"}')
+
+if success then
+    print(res.foo) -- lua table
+else
+    print(res) -- pretty printed error
+end
+```
+
+Thanks to [A-Cloud-Ninja](https://github.com/A-Cloud-Ninja) for adding Lua support!
 
 ## Writing Corn
 

--- a/libcorn/Cargo.toml
+++ b/libcorn/Cargo.toml
@@ -11,6 +11,12 @@ keywords = ["configuration", "language", "wasm", "pest", "peg"]
 [features]
 wasm = ["wasm-bindgen", "serde-wasm-bindgen", "console_error_panic_hook", "wee_alloc"]
 bench = ["criterion"]
+lua51 = ["mlua/lua51"]
+lua52 = ["mlua/lua52"]
+lua53 = ["mlua/lua53"]
+lua54 = ["mlua/lua54"]
+luajit = ["mlua/luajit"]
+luajit52 = ["mlua/luajit52"]
 
 [lib]
 name = "corn"
@@ -26,6 +32,7 @@ wasm-bindgen = { version = "0.2.83", optional = true }
 serde-wasm-bindgen = { version = "0.5.0", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
+mlua = { version = "0.8.9", features = ["vendored", "module", "macros", "serialize"], optional = true }
 
 # bench
 criterion = { version = "0.5.1", features = ["html_reports"], optional = true }

--- a/libcorn/src/lib.rs
+++ b/libcorn/src/lib.rs
@@ -10,6 +10,16 @@ pub mod error;
 mod parser;
 
 mod de;
+#[cfg(any(
+    feature = "lua",
+    feature = "lua51",
+    feature = "lua52",
+    feature = "lua53",
+    feature = "lua54",
+    feature = "luajit",
+    feature = "luajit52"
+))]
+mod lua;
 #[cfg(feature = "wasm")]
 mod wasm;
 

--- a/libcorn/src/lua.rs
+++ b/libcorn/src/lua.rs
@@ -1,0 +1,24 @@
+use crate::Value;
+use mlua::prelude::*;
+
+impl<'lua> ToLua<'lua> for Value<'lua> {
+    fn to_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
+        lua.to_value(&self)
+    }
+}
+
+fn lua_parse(lua: &Lua, config: String) -> LuaResult<LuaValue> {
+    let res = crate::parse(&config);
+    match res {
+        Ok(v) => Ok(lua.to_value(&v)?),
+        Err(e) => Err(LuaError::RuntimeError(e.to_string())),
+    }
+}
+
+#[mlua::lua_module]
+fn libcorn(lua: &Lua) -> LuaResult<LuaTable> {
+    let exports = lua.create_table()?;
+    let parse = lua.create_function(lua_parse)?;
+    exports.set("parse", parse)?;
+    Ok(exports)
+}


### PR DESCRIPTION
Introduces the structure for a Lua process to load libcorn.so

Currently when this compiles, it creates a `liblibcorn.so` which has to be renamed during use from a pure Lua perspective, to `libcorn.so` (this is an issue with how Lua looks for and loads libraries, rather than a rust problem directly)